### PR TITLE
Problem: We have no tests and we must scream.

### DIFF
--- a/channeler.go
+++ b/channeler.go
@@ -1,0 +1,37 @@
+package gogozmq
+
+const (
+	Push = 7
+	Pull = 8
+)
+
+type Channeler struct {
+	sockType  int
+	endpoints string
+	subscribe string
+	SendChan  chan<- [][]byte
+	RecvChan  <-chan [][]byte
+}
+
+func newChanneler(sockType int, endpoints, subscribe string) *Channeler {
+	sendChan := make(chan [][]byte)
+	recvChan := make(chan [][]byte)
+	return &Channeler{
+		sockType:  sockType,
+		endpoints: endpoints,
+		subscribe: subscribe,
+		SendChan:  sendChan,
+		RecvChan:  recvChan,
+	}
+}
+
+func NewPushChanneler(endpoints string) *Channeler {
+	return newChanneler(Push, endpoints, "")
+}
+
+func NewPullChanneler(endpoints string) *Channeler {
+	return newChanneler(Pull, endpoints, "")
+}
+
+func (c *Channeler) Destroy() {
+}

--- a/channeler_test.go
+++ b/channeler_test.go
@@ -1,0 +1,38 @@
+package gogozmq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/zeromq/goczmq"
+)
+
+func TestPushChanneler(t *testing.T) {
+	push := NewPushChanneler("inproc://TestPubChanneler")
+	defer push.Destroy()
+
+	pull, err := goczmq.NewPull("inproc://TestPubChanneler")
+	if err != nil {
+		t.Error(err)
+	}
+	defer pull.Destroy()
+
+	select {
+	case push.SendChan <- [][]byte{[]byte("hello")}:
+	case <-time.After(1):
+		t.Fatalf("send timed out")
+	}
+
+	resp, err := pull.RecvMessageNoWait()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, got := 1, len(resp); want != got {
+		t.Errorf("want '%#v', got '%#v'", want, got)
+	}
+
+	if want, got := "hello", string(resp[0]); want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}


### PR DESCRIPTION
* Add a starting Channeler implementation that matches the API from goczmq.Channeler, and does nothing.
* Add a test that fails.

Note that this PR adds a dependency on goczmq.  It uses a goczmq Pull socket in the test.  When we have a pure go implementation of Channeler that can pass this test by connecting to a goczmq Pull socket and sending a valid message, we'll have passed a hurdle.

Note that I chose Push / Pull for this first test because they are very simple sockets.  Client / Server sockets have the additional overhead of handling client ids.  Pub / Sub sockets have the added complexity of dealing with subscription messages.  So, let's get a simple unidirectional message between a pure go Push and a goczmq Pull working first.