### PR TITLE
problem: send goroutine is keep on running after the channeler is destroyed

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -20,4 +20,22 @@ func TestPushChanneler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	push.SendChan <- [][]byte{[]byte("Hello")}
+
+	msg, more, err := pull.RecvFrame()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(msg)
+
+	if text != "Hello" {
+		t.Fatal("Wrong message")
+	}
+
+	if more != 0 {
+		t.Fatal("More flag is wrong")
+	}
 }

--- a/zmtp.go
+++ b/zmtp.go
@@ -6,14 +6,22 @@ import (
 )
 
 const (
-	Push                 byte          = 8
-	Pull                 byte          = 7
-	zmtpVersion          byte          = 1
-	zmtpHandshakeTimeout time.Duration = time.Millisecond * 100
+	Push                     byte          = 8
+	Pull                     byte          = 7
+	zmtpVersion              byte          = 1
+	zmtpHandshakeTimeout     time.Duration = time.Millisecond * 100
+	shortMessageEnvelopeSize               = 2
+	flagIndex                              = 0
+	shortSizeIndex                         = 1
+	finalShortSizeFlag                     = 0
 )
 
 type zmtpGreet struct {
 	sockType byte
+}
+
+type zmtpMessage struct {
+	msg [][]byte
 }
 
 func (z *zmtpGreet) send(w io.Writer) (int, error) {
@@ -23,4 +31,21 @@ func (z *zmtpGreet) send(w io.Writer) (int, error) {
 	greeting := []byte{0xff, 0, 0, 0, 0, 0, 0, 0, 1, 0x7f, zmtpVersion, z.sockType, finalShort, identitySize}
 
 	return w.Write(greeting)
+}
+
+func (z *zmtpMessage) send(w io.Writer) (int, error) {
+	payloadSize := len(z.msg[0])
+	envelopeSize := shortMessageEnvelopeSize + payloadSize
+	
+	// only support single part and short message (under 255 bytes)
+	envelope := make([]byte, envelopeSize)
+
+	envelope[flagIndex] = finalShortSizeFlag
+	envelope[shortSizeIndex] = byte(payloadSize)
+
+	if payloadSize > 0 {
+		copy(envelope[2:], z.msg[0])
+	}
+
+	return w.Write(envelope)
 }


### PR DESCRIPTION
should be merged after #12 

part of the destroy process closing the send channel and waiting for confirmation from the go-routine that the sending is complete