### PR TITLE
Problem: sock still did not provide net.Conn interface

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -28,7 +28,7 @@ func TestPushChanneler(t *testing.T) {
 	}
 
 	if want, have := "Hello", string(msg); want != have {
-		t.Error("want %#v, have %#v", want, have)
+		t.Errorf("want %#v, have %#v", want, have)
 	}
 
 	if want, have := 0, more; want != have {

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,107 @@
+package gogozmq
+
+import (
+	"bytes"
+	"net"
+)
+
+func verifyProtoSignature(conn net.Conn, buf []byte) error {
+	n, err := conn.Read(buf[:1])
+	if err != nil {
+		return err
+	}
+
+	if n != 1 {
+		return ErrProtoBad
+	}
+
+	if buf[0] != signature[0] {
+		return ErrProtoBad
+	}
+
+	_, err = conn.Read(buf[1:10])
+	if err != nil {
+		return err
+	}
+
+	if bytes.Compare(buf[0:10], signature) != 0 {
+		return ErrProtoBad
+	}
+
+	return err
+}
+
+func verifyProtoVersion(conn net.Conn, buf []byte) error {
+	n, err := conn.Read(buf[10:11])
+	if err != nil {
+		return err
+	}
+
+	if n != 1 {
+		return ErrProtoBad
+	}
+
+	if buf[10] < zmtpVersion {
+		return ErrProtoBad
+	}
+
+	return nil
+}
+
+func verifyProtoSockType(conn net.Conn, buf []byte) error {
+	n, err := conn.Read(buf[11:12])
+	if err != nil {
+		return err
+	}
+
+	if n != 1 {
+		return ErrProtoBad
+	}
+
+	if buf[11] != Pull {
+		return ErrProtoSockType
+	}
+
+	return err
+}
+
+func verifyProtoIdentity(conn net.Conn, buf []byte) error {
+	n, err := conn.Read(buf[12:14])
+	if err != nil {
+		return err
+	}
+
+	if n != 2 {
+		return ErrProtoBad
+	}
+
+	if buf[12] != 0 {
+		return ErrProtoIdentity
+	}
+
+	if buf[13] != 0 {
+		return ErrProtoIdentity
+	}
+
+	return nil
+}
+
+func clientHandshake(conn net.Conn, buf []byte) error {
+	err := verifyProtoSignature(conn, buf)
+	if err != nil {
+		return err
+	}
+
+	err = verifyProtoVersion(conn, buf)
+	if err != nil {
+		return err
+	}
+
+	err = verifyProtoSockType(conn, buf)
+	if err != nil {
+		return err
+	}
+
+	err = verifyProtoIdentity(conn, buf)
+	return err
+}

--- a/sock.go
+++ b/sock.go
@@ -1,177 +1,106 @@
 package gogozmq
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 )
 
-func (s *Sock) verifyProtoSignature(buf []byte) error {
-	n, err := s.conn.Read(buf[:1])
-	if err != nil {
-		return err
-	}
-
-	if n != 1 {
-		return ErrProtoBad
-	}
-
-	if buf[0] != signature[0] {
-		return ErrProtoBad
-	}
-
-	_, err = s.conn.Read(buf[1:10])
-	if err != nil {
-		return err
-	}
-
-	if bytes.Compare(buf[0:10], signature) != 0 {
-		return ErrProtoBad
-	}
-
-	return err
-}
-
-func (s *Sock) verifyProtoVersion(buf []byte) error {
-	n, err := s.conn.Read(buf[10:11])
-	if err != nil {
-		return err
-	}
-
-	if n != 1 {
-		return ErrProtoBad
-	}
-
-	if buf[10] < zmtpVersion {
-		return ErrProtoBad
-	}
-
-	return nil
-}
-
-func (s *Sock) verifyProtoSockType(buf []byte) error {
-	n, err := s.conn.Read(buf[11:12])
-	if err != nil {
-		return err
-	}
-
-	if n != 1 {
-		return ErrProtoBad
-	}
-
-	if buf[11] != Pull {
-		return ErrProtoSockType
-	}
-
-	return err
-}
-
-func (s *Sock) verifyProtoIdentity(buf []byte) error {
-	n, err := s.conn.Read(buf[12:14])
-	if err != nil {
-		return err
-	}
-
-	if n != 2 {
-		return ErrProtoBad
-	}
-
-	if buf[12] != 0 {
-		return ErrProtoIdentity
-	}
-
-	if buf[13] != 0 {
-		return ErrProtoIdentity
-	}
-
-	return nil
+type Conn interface {
+	net.Conn
+	Connect(endpoint string) error
+	CurrentIdx() int
 }
 
 type Sock struct {
-	conn     net.Conn
-	sockType byte
-	address  string
+	conns      []net.Conn
+	currentIdx int
+	sockType   byte
+	address    string
 }
 
-func NewPush(address string) (Sock, error) {
+func NewPushConn(address string) (Conn, error) {
 	s := Sock{
-		sockType: Push,
-		address:  address,
+		currentIdx: 0,
+		sockType:   Push,
+		address:    address,
 	}
 
-	var err error
 	addrParts := strings.Split(s.address, "://")
-	s.conn, err = net.Dial(addrParts[0], addrParts[1])
+	conn, err := net.Dial(addrParts[0], addrParts[1])
 	if err != nil {
 		return s, err
 	}
+	s.conns = append(s.conns, conn)
 
 	zmtpGreetOutgoing := &zmtpGreeter{
 		sockType: s.sockType,
 	}
 
-	_, err = zmtpGreetOutgoing.send(s.conn)
+	_, err = zmtpGreetOutgoing.send(s.conns[s.currentIdx])
 	if err != nil {
 		return s, err
 	}
 
 	buf := make([]byte, 64)
 
-	err = s.verifyProtoSignature(buf)
-	if err != nil {
-		return s, err
-	}
-
-	err = s.verifyProtoVersion(buf)
-	if err != nil {
-		return s, err
-	}
-
-	err = s.verifyProtoSockType(buf)
-	if err != nil {
-		return s, err
-	}
-
-	err = s.verifyProtoIdentity(buf)
-	if err != nil {
-		return s, err
-	}
-
+	err = clientHandshake(conn, buf)
 	return s, err
 }
 
-func (s *Sock) Read(b []byte) (n int, err error) {
+func (s Sock) Connect(endpoint string) error {
+	addrParts := strings.Split(s.address, "://")
+	_, err := net.Dial(addrParts[0], addrParts[1])
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (s Sock) CurrentIdx() int {
+	return s.currentIdx
+}
+
+func (s Sock) Read(b []byte) (n int, err error) {
 	return 0, fmt.Errorf("I can't read")
 }
 
-func (s *Sock) Write(b []byte) (n int, err error) {
+func (s Sock) Write(b []byte) (n int, err error) {
 	zmtpMessageOutgoing := &zmtpMessage{}
 	zmtpMessageOutgoing.msg = [][]byte{b}
-	return zmtpMessageOutgoing.send(s.conn)
+	n, err = zmtpMessageOutgoing.send(s.conns[s.currentIdx])
+	s.currentIdx++
+	return n, err
 }
 
-func (s *Sock) Close() error {
-	return s.conn.Close()
+func (s Sock) Close() error {
+	var err error
+	for i := 0; i < len(s.conns); i++ {
+		err = s.conns[i].Close()
+		if err != nil {
+			return err
+		}
+	}
+	return err
 }
 
-func (s *Sock) LocalAddr() net.Addr {
-	return s.conn.LocalAddr()
+func (s Sock) LocalAddr() net.Addr {
+	return s.conns[s.currentIdx].LocalAddr()
 }
 
-func (s *Sock) RemoteAddr() net.Addr {
-	return s.conn.RemoteAddr()
+func (s Sock) RemoteAddr() net.Addr {
+	return s.conns[s.currentIdx].RemoteAddr()
 }
 
-func (s *Sock) SetDeadLine(t time.Time) error {
+func (s Sock) SetDeadline(t time.Time) error {
 	return fmt.Errorf("I don't do deadlines")
 }
 
-func (s *Sock) SetReadDeadline(t time.Time) error {
+func (s Sock) SetReadDeadline(t time.Time) error {
 	return fmt.Errorf("I don't do deadlines")
 }
 
-func (s *Sock) SetWriteDeadline(t time.Time) error {
+func (s Sock) SetWriteDeadline(t time.Time) error {
 	return fmt.Errorf("I don't do deadlines")
 }

--- a/sock_test.go
+++ b/sock_test.go
@@ -7,22 +7,22 @@ import (
 )
 
 func TestPushSockShortMessage(t *testing.T) {
-	endpoint := "tcp://127.0.0.1:9999"
+	endpoint1 := "tcp://127.0.0.1:9998"
 
-	pull, err := goczmq.NewPull(endpoint)
+	pull1, err := goczmq.NewPull(endpoint1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pull.Destroy()
+	defer pull1.Destroy()
 
-	push, err := NewPush(endpoint)
+	push, err := NewPushConn(endpoint1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	push.Write([]byte("Hello"))
 
-	msg, more, err := pull.RecvFrame()
+	msg, more, err := pull1.RecvFrame()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zmtp.go
+++ b/zmtp.go
@@ -2,6 +2,7 @@ package gogozmq
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"time"
 )
@@ -55,6 +56,10 @@ func (z *zmtpGreeter) send(w io.Writer) (int, error) {
 
 func (z *zmtpMessage) send(w io.Writer) (int, error) {
 	payloadSize := len(z.msg[0])
+	if payloadSize > 255 {
+		return 0, fmt.Errorf("long messages not supported")
+	}
+
 	envelopeSize := shortMessageEnvelopeSize + payloadSize
 
 	// only support single part and short message (under 255 bytes)
@@ -66,6 +71,5 @@ func (z *zmtpMessage) send(w io.Writer) (int, error) {
 	if payloadSize > 0 {
 		copy(envelope[2:], z.msg[0])
 	}
-
 	return w.Write(envelope)
 }


### PR DESCRIPTION
Solution: Fix some issues that were keeping it from satisfying net.Conn
Auxiliary: Small refactor to split duplicated handshake methods from channeler and sock into a helpers that are now used from both of them, to reduce code duplication.

