### PR TITLE
Problem: NewPushConn should take multiple endpoints

### DIFF
--- a/channeler.go
+++ b/channeler.go
@@ -53,9 +53,7 @@ func newChanneler(sockType byte, endpoints, subscribe string) (*Channeler, error
 		return c, err
 	}
 
-	buf := make([]byte, 64)
-
-	err = clientHandshake(c.conn, buf)
+	err = clientHandshake(c.conn)
 	go c.sendMessages(sendChan)
 	return c, err
 }

--- a/helpers.go
+++ b/helpers.go
@@ -86,7 +86,8 @@ func verifyProtoIdentity(conn net.Conn, buf []byte) error {
 	return nil
 }
 
-func clientHandshake(conn net.Conn, buf []byte) error {
+func clientHandshake(conn net.Conn) error {
+	buf := make([]byte, 64)
 	err := verifyProtoSignature(conn, buf)
 	if err != nil {
 		return err


### PR DESCRIPTION
Solution: Implement it.
Auxiliary: Refactored handshake to not require a based buffer, as constructing the buffer for verification should not be a concern of the caller.