### PR TITLE
Problem: channeler should not have its own msg implementation

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -20,7 +20,7 @@ func TestPushChanneler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	push.SendChan <- [][]byte{[]byte("Hello")}
+	push.SendChan <- []byte("Hello")
 
 	msg, more, err := pull.RecvFrame()
 	if err != nil {


### PR DESCRIPTION
Solution: refactor Channeler to use our Conn interface.  Additionally, move Channeler to use single frame messages as we currently have no intention to support multi-part messages.